### PR TITLE
Feature/harden socket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "4"
-  - "5"
+  - 4
+  - 5
 git:
   depth: 10

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,0 +1,12 @@
+
+0.4.0
+ - **API/Breaking**: prefix 'private' members with an underscore
+ - **Breaking**: Include a dedicated auth method and fix issues with authentication. Previously there were some issues, such as the promise never resolving if you called auth before the socket connected even though we supposedly spooled the reply. I include this as breaking since using `.call('auth', ` will no longer save those credentials to be reused on reconnect
+ - **Breaking:** drop support for 0.12 (in our dependencies)
+ - **Breaking:** on the chat server we now reply to _every_ method we get, so after a timeout we throw an error on the socket (where previously the promise returned from .call() would resolve to undefined) if we don't get a reply. The error class is exposed as `BeamSocket.TimeoutError`.
+ - Add compatibility with browser-based sockets
+ - Fix bias in round-robining
+ - Use a backoff for chat reconnection
+ - Use a generic A+ promise on BeamSocket.Promise so it can be swapped out by consumers (replacing with rsvp on our frontend)
+ - Add unit tests where they were previously skimpy
+ - Fix an issue with the socket re-opening if it was closed after a connection failure

--- a/lib/ws/factory.js
+++ b/lib/ws/factory.js
@@ -1,12 +1,47 @@
-var WebSocket = require('ws');
+var NodeWS = require('ws');
+var isNode = typeof window === 'undefined';
 
 /**
- * Factor function to create a websocket. Lets us mock it later.
+ * Wraps a DOM socket with EventEmitter-like syntax.
+ * @param  {Socket} socket
+ * @return {Socket}
+ */
+function wrapDOM(socket) {
+    function wrapHandler(event, fn) {
+        return (ev) => {
+            if (event === 'message') {
+                fn(ev.data);
+            } else {
+                fn(ev);
+            }
+        };
+    }
+
+    socket.on = function (event, listener) {
+        const wrapped = wrapHandler(event, listener);
+        socket.addEventListener(event, wrapped);
+    };
+
+    socket.once = function (event, listener) {
+        const wrapped = wrapHandler(event, listener);
+        socket.addEventListener(event, (ev) => {
+            wrapped(ev);
+            socket.removeEventListener(event, wrapped);
+        });
+    };
+
+    return socket;
+}
+
+/**
+ * Factory function to create a websocket. Lets us mock it later.
  * @param  {String} address
- * @param  {Array|String=} protocol
- * @param  {Object=} options
  * @return {WebSocket}
  */
-module.exports.create = function (address, protocol, options) {
-    return new WebSocket(address, protocol, options);
+module.exports.create = function (address) {
+    if (isNode) {
+        return new NodeWS(address);
+    }
+
+    return wrapDOM(new WebSocket(address));
 };

--- a/lib/ws/factory.js
+++ b/lib/ws/factory.js
@@ -39,9 +39,10 @@ function wrapDOM(socket) {
  * @return {WebSocket}
  */
 module.exports.create = function (address) {
-    if (isNode) {
-        return new NodeWS(address);
+    var ws = new WebSocket(address);
+    if (!isNode) {
+        ws = wrapDOM(ws);
     }
 
-    return wrapDOM(new WebSocket(address));
+    return ws;
 };

--- a/lib/ws/factory.js
+++ b/lib/ws/factory.js
@@ -1,5 +1,5 @@
-var NodeWS = require('ws');
 var isNode = typeof window === 'undefined';
+var WebSocket = isNode ? require('ws') : window.WebSocket;
 
 /**
  * Wraps a DOM socket with EventEmitter-like syntax.

--- a/lib/ws/readme.md
+++ b/lib/ws/readme.md
@@ -16,9 +16,10 @@ var socket = new BeamSocket(data.endpoints).boot();
 
 // You don't need to wait for the socket to connect before calling methods,
 // we spool them and run them when connected automatically!
-socket.call('auth', [channel.id, user.id, data.authkey])
+socket.auth(channel.id, user.id, data.authkey)
     .then(function () {
         console.log('You are now authenticated!');
+        return socket.call('msg', ['Hello world!']);
     }).catch(function (err) {
         console.log('Oh no! An error occurred!')
     });
@@ -52,6 +53,10 @@ Returns a status constant (as listed above). Should be compared like `socket.get
 ### socket.isConnected()
 
 Return whether the socket is currently connected.
+
+### socket.auth(channel[, user, authkey])
+
+Joins the chat of a certain channel by its ID. If you want to join anonymously (without being able to chat) you can omit the `user` and `authkey`. The `user` is the user ID you're authenticating as, the authkey is the alphanumeric token returns from `GET /api/v1/chats/:id`.
 
 ### socket.call(method, [args], [options])
 

--- a/lib/ws/ws.js
+++ b/lib/ws/ws.js
@@ -31,10 +31,10 @@ function BeamSocket (addresses) {
     // The status of the socket connection.
     this.status = BeamSocket.IDLE;
 
-    // Number of retries to do before we give up connecting.
-    this.retries = 0;
-    // Max number of retries to do.
-    this.maxRetries = 5;
+    // Counter of the current number of reconnect retries, and the number of
+    // retries before we reset our reconnect attempts.
+    this._retries = 0;
+    this._retryWrap = 7; // max 2 minute retry time
     // Wait duration between retries.
     this.retryDelay = 500;
     // Timeout waiting to reconnect
@@ -86,6 +86,33 @@ BeamSocket.prototype.getAddress = function () {
     return this._addresses[this._addressOffset];
 };
 
+/**
+ * Returns how long to wait before attempting to reconnect. This does TCP-style
+ * limited exponential backoff.
+ * @return {Number}
+ */
+BeamSocket.prototype._getNextReconnectInterval = function () {
+    var power = (this._retries++ % this._retryWrap) + Math.round(Math.random());
+    return (1 << power) * 500;
+};
+
+/**
+ * _handleClose is called when the websocket closes or emits an error. If
+ * we weren't gracefully closed, we'll try to reconnect.
+ */
+BeamSocket.prototype._handleClose = function () {
+    this.ws = null;
+    if (this.status === BeamSocket.CLOSING) {
+        this.status = BeamSocket.CLOSED;
+        return this.emit('closed');
+    }
+
+    this.status = BeamSocket.CONNECTING;
+    this._reconnectTimeout = setTimeout(
+        this.boot.bind(this),
+        this._getNextReconnectInterval()
+    );
+};
 
 /**
  * Starts a socket client. Attaches events and tries to connect to a
@@ -101,43 +128,24 @@ BeamSocket.prototype.boot = function () {
     this.status = BeamSocket.CONNECTING;
 
     // Websocket connection has been established.
-    ws.on('open', this.unspool.bind(this));
+    ws.on('open', function () {
+        self.unspool.apply(self, arguments);
+    });
 
     // We got an incoming data packet.
-    ws.on('message', function (data, flags) {
-        self.parsePacket(data, flags);
+    ws.on('message', function () {
+        self.parsePacket.apply(self, arguments);
     });
 
     // Websocket connection closed
     ws.on('close', function () {
-        self.emit('closed');
-
-        // If we errored, we are already trying to reconnect, don't
-        // change the BeamSocket.
-        if (self.status !== BeamSocket.CONNECTING) {
-            self.status = BeamSocket.CLOSED;
-        }
-
-        this.ws = null;
+        self._handleClose.apply(self, arguments);
     });
 
     // Websocket hit an error and is about to close.
     ws.on('error', function (err) {
         self.emit('error', err);
         ws.close();
-
-        // Check to see if we should reconnect.
-        if (self.retries++ > self.maxRetries) {
-            self.status = ABORTED;
-            return;
-        }
-
-        // Set the status and retry booting after a bit.
-        self.status = BeamSocket.CONNECTING;
-        self._reconnectTimeout = setTimeout(
-            self.boot.bind(self),
-            self.retries * 500
-        );
     });
 
     return this;
@@ -339,15 +347,17 @@ BeamSocket.prototype.call = function (method, args_, options_) {
 };
 
 /**
- * Closes the existing websocket.
+ * Closes the websocket gracefully.
  * @access public
  */
 BeamSocket.prototype.close = function () {
     if (this.ws) {
         this.ws.close();
+        this.status = BeamSocket.CLOSING;
+    } else {
+        clearTimeout(this._reconnectTimeout);
+        this.status = BeamSocket.CLOSED;
     }
-
-    clearTimeout(this._reconnectTimeout);
 };
 
 /**
@@ -366,12 +376,12 @@ BeamSocket.Promise = require('bluebird');
     'IDLE',
     /** We successfully connected */
     'CONNECTED',
+    /** The socket was is closing gracefully. */
+    'CLOSING',
     /** The socket was closed gracefully. */
     'CLOSED',
     /** We're currently trying to connect */
     'CONNECTING',
-    /** We tried several times to connect, but were unable to do so. */
-    'ABORTED',
 ].forEach(function (status, i) {
     BeamSocket[status] = i;
 });

--- a/lib/ws/ws.js
+++ b/lib/ws/ws.js
@@ -318,19 +318,23 @@ BeamSocket.prototype.call = function (method, args_, options_) {
         return;
     }
 
+    var timeout;
     return new BeamSocket.Promise(function (resolve, reject) {
-        var timeout = setTimeout(function () {
-            reject(new TimeoutError())
+        timeout = setTimeout(function () {
+            reject(new TimeoutError());
         }, self.callTimeout);
 
-        self._replies[id] = new Reply(function (value) {
-            clearTimeout(timeout);
-            resolve(value);
-        }, reject);
-    }).catch(TimeoutError, function () {
+        self._replies[id] = new Reply(resolve, reject);
+    }).catch(function (err) {
         // After five seconds, if we haven't gotten a reply, remove
         // the method reply. Keeps memory leaks down.
-        delete self._replies[id];
+        if (err instanceof TimeoutError) {
+            delete self._replies[id];
+        } else {
+            throw err;
+        }
+    }).finally(function () {
+        clearTimeout(timeout);
     });
 };
 

--- a/lib/ws/ws.js
+++ b/lib/ws/ws.js
@@ -338,9 +338,8 @@ BeamSocket.prototype.call = function (method, args_, options_) {
         // the method reply. Keeps memory leaks down.
         if (err instanceof TimeoutError) {
             delete self._replies[id];
-        } else {
-            throw err;
         }
+        throw err;
     }).finally(function () {
         clearTimeout(timeout);
     });
@@ -392,5 +391,11 @@ BeamSocket.Promise = require('bluebird');
  */
 function TimeoutError() { Error.call(this); }
 TimeoutError.prototype = Object.create(Error.prototype);
+
+/**
+ * Reference to the TimeoutError class.
+ * @type {TimeoutError}
+ */
+BeamSocket.TimeoutError = TimeoutError;
 
 module.exports = BeamSocket;

--- a/lib/ws/ws.js
+++ b/lib/ws/ws.js
@@ -1,6 +1,5 @@
 var util = require('util');
 var events = require('events');
-var Bluebird = require('bluebird');
 
 var Reply = require('./reply');
 var errors = require('../errors');
@@ -18,13 +17,13 @@ function BeamSocket (addresses) {
     events.EventEmitter.call(this);
 
     // Which connection we use in our load balancing.
-    this.addressOffset = Math.floor(Math.random() * addresses.length) - 1;
+    this._addressOffset = Math.floor(Math.random() * addresses.length);
 
     // List of addresses we can connect to.
-    this.addresses = addresses;
+    this._addresses = addresses;
 
     // Spool to store events queued when the connection is lost.
-    this.spool = [];
+    this._spool = [];
 
     // The WebSocket instance we're currently connected with.
     this.ws = null;
@@ -38,19 +37,25 @@ function BeamSocket (addresses) {
     this.maxRetries = 5;
     // Wait duration between retries.
     this.retryDelay = 500;
+    // Timeout waiting to reconnect
+    this._reconnectTimeout = null;
+
+    // Number of milliseconds to wait in .call() before we give up waiting
+    // for the reply. Used to prevent leakages.
+    this.callTimeout = 1000 * 60;
 
     // Map of call IDs to promises that should be resolved on
     // method responses.
-    this.replies = {};
+    this._replies = {};
 
     // Authentication packet store that we'll resend if we have to reconnect.
-    this.authpacket = null;
+    this._authpacket = null;
 
     // Counter for method calls.
-    this.callNo = 0;
+    this._callNo = 0;
 }
 
-util.inherits(BeamSocket, events.EventEmitter);
+BeamSocket.prototype = Object.create(events.EventEmitter.prototype);
 
 /**
  * Gets the status of the socket connection.
@@ -74,11 +79,11 @@ BeamSocket.prototype.isConnected = function () {
  * @return {String}
  */
 BeamSocket.prototype.getAddress = function () {
-    if (++this.addressOffset >= this.addresses.length) {
-        this.addressOffset = 0;
+    if (++this._addressOffset >= this._addresses.length) {
+        this._addressOffset = 0;
     }
 
-    return this.addresses[this.addressOffset];
+    return this._addresses[this._addressOffset];
 };
 
 
@@ -93,12 +98,15 @@ BeamSocket.prototype.getAddress = function () {
 BeamSocket.prototype.boot = function () {
     var self = this;
     var ws = this.ws = factory.create(this.getAddress());
+    this.status = BeamSocket.CONNECTING;
 
     // Websocket connection has been established.
     ws.on('open', this.unspool.bind(this));
 
     // We got an incoming data packet.
-    ws.on('message', this.parsePacket.bind(this));
+    ws.on('message', function (data, flags) {
+        self.parsePacket(data, flags);
+    });
 
     // Websocket connection closed
     ws.on('close', function () {
@@ -110,26 +118,26 @@ BeamSocket.prototype.boot = function () {
             self.status = BeamSocket.CLOSED;
         }
 
-        // Let v8 clean up after itself.
-        ws = null;
-        self = null;
+        this.ws = null;
     });
 
     // Websocket hit an error and is about to close.
     ws.on('error', function (err) {
         self.emit('error', err);
+        ws.close();
 
         // Check to see if we should reconnect.
-        if (self.retries++ < self.maxRetries) {
-            // Set the status and retry booting after a bit.
-            self.status = BeamSocket.CONNECTING;
-            setTimeout(self.boot.bind(self), 500);
-
-            // Terminate the socket to make sure it closes.
-            ws.terminate();
-        } else {
+        if (self.retries++ > self.maxRetries) {
             self.status = ABORTED;
+            return;
         }
+
+        // Set the status and retry booting after a bit.
+        self.status = BeamSocket.CONNECTING;
+        self._reconnectTimeout = setTimeout(
+            self.boot.bind(self),
+            self.retries * 500
+        );
     });
 
     return this;
@@ -148,8 +156,8 @@ BeamSocket.prototype.unspool = function () {
 
     // If we already authed, it means we're reconnecting and should
     // establish authentication again.
-    if (this.authpacket) {
-        this.call(authMethod, this.authpacket, { force: true })
+    if (this._authpacket) {
+        this.call(authMethod, this._authpacket, { force: true })
             .then(bang)
             .catch(function () {
                 self.emit('error', new errors.AuthenticationFailedError());
@@ -165,13 +173,13 @@ BeamSocket.prototype.unspool = function () {
     // ready to take direct calls again.
     function bang () {
         // Send any spooled events that we have.
-        for (var i = 0; i < self.spool.length; i++) {
-            self.send(self.spool[i], { force: true });
+        for (var i = 0; i < self._spool.length; i++) {
+            self.send(self._spool[i], { force: true });
         }
-        self.spool = [];
+        self._spool = [];
 
         // Finally, tell the world we're connected.
-        self.retries = 0;
+        self._retries = 0;
         self.status = BeamSocket.CONNECTED;
         self.emit('connected');
 
@@ -208,10 +216,10 @@ BeamSocket.prototype.parsePacket = function (data, flags) {
 
         case 'reply':
             // Try to look up the packet reply handler, and call it if we can.
-            var reply = this.replies[packet.id];
+            var reply = this._replies[packet.id];
             if (typeof reply !== 'undefined') {
                 reply.handle(packet);
-                delete this.replies[packet.id];
+                delete this._replies[packet.id];
             }
             // Otherwise emit an error. This might happen occasionally,
             // but failing silently is lame.
@@ -247,7 +255,7 @@ BeamSocket.prototype.send = function (data, options_) {
         this.ws.send(JSON.stringify(data));
         this.emit('sent', data);
     } else if (data.method !== authMethod) {
-        this.spool.push(data);
+        this._spool.push(data);
         this.emit('spooled', data);
     }
 };
@@ -273,31 +281,34 @@ BeamSocket.prototype.call = function (method, args_, options_) {
 
     // Save the arguments to any auth call we get.
     if (method === authMethod) {
-        this.authpacket = args;
+        this._authpacket = args;
     }
 
     // Send out the data
-    var id = this.callNo++, self = this;
+    var id = this._callNo++, self = this;
     this.send({ type: 'method', method: method, arguments: args, id: id }, options);
 
 
     // Then create and return a promise that's resolved when we get
     // a reply, if we expect one to be given.
-    if (!options.noReply) {
-        return new Bluebird(function (resolve, reject) {
-            self.replies[id] = new Reply(resolve, reject);
-        }).timeout(5000)
-          .catch(Bluebird.TimeoutError, function () {
-            // After five seconds, if we haven't gotten a reply, remove
-            // the method reply. Keeps memory leaks down.
-            delete self.replies[id];
-          })
-          .finally(function () {
-            // null to prevent memory leaks
-            id = null;
-            self = null;
-          });
+    if (options.noReply) {
+        return;
     }
+
+    return new BeamSocket.Promise(function (resolve, reject) {
+        var timeout = setTimeout(function () {
+            reject(new TimeoutError())
+        }, self.callTimeout);
+
+        self._replies[id] = new Reply(function (value) {
+            clearTimeout(timeout);
+            resolve(value);
+        }, reject);
+    }).catch(TimeoutError, function () {
+        // After five seconds, if we haven't gotten a reply, remove
+        // the method reply. Keeps memory leaks down.
+        delete self._replies[id];
+    });
 };
 
 /**
@@ -308,7 +319,15 @@ BeamSocket.prototype.close = function () {
     if (this.ws) {
         this.ws.close();
     }
+
+    clearTimeout(this._reconnectTimeout);
 };
+
+/**
+ * Promise class to use in .call
+ * @type {Promise}
+ */
+BeamSocket.Promise = require('bluebird');
 
 /**
  * List of available statuses.
@@ -329,5 +348,12 @@ BeamSocket.prototype.close = function () {
 ].forEach(function (status, i) {
     BeamSocket[status] = i;
 });
+
+/**
+ * A TimeoutError is thrown in call if we don't get a response from the
+ * chat server within a certain interval.
+ */
+function TimeoutError() { Error.call(this); }
+TimeoutError.prototype = Object.create(Error.prototype);
 
 module.exports = BeamSocket;

--- a/lib/ws/ws.js
+++ b/lib/ws/ws.js
@@ -158,6 +158,9 @@ BeamSocket.prototype.unspool = function () {
     // establish authentication again.
     if (this._authpacket) {
         this.call(authMethod, this._authpacket, { force: true })
+            .then(function (result) {
+                self.emit('authresult', result);
+            })
             .then(bang)
             .catch(function () {
                 self.emit('error', new errors.AuthenticationFailedError());
@@ -261,6 +264,31 @@ BeamSocket.prototype.send = function (data, options_) {
 };
 
 /**
+ * auth sends a packet over the socket to authenticate with a chat server
+ * and join a specified channel. If you wish to join anonymously, user
+ * and authkey can be omitted.
+ * @param  {Number} id
+ * @param  {Number} [user]
+ * @param  {String} [authkey]
+ * @return {Promise}
+ */
+BeamSocket.prototype.auth = function (id, user, authkey) {
+    this._authpacket = [id, user, authkey];
+
+    // Two cases here: if we're already connected, with send the auth
+    // packet immediately. Otherwise we wait for a `connected` event,
+    // which won't be sent until after we re-authenticate.
+    if (this.isConnected()) {
+        return this.call('auth', [id, user, authkey]);
+    }
+
+    var self = this;
+    return new BeamSocket.Promise(function (resolve) {
+        self.once('authresult', resolve);
+    });
+};
+
+/**
  * Runs a method on the socket. Returns a promise that is rejected or
  * resolved upon reply.
  * @access public
@@ -278,11 +306,6 @@ BeamSocket.prototype.call = function (method, args_, options_) {
         args = [];
     }
     options = options || {};
-
-    // Save the arguments to any auth call we get.
-    if (method === authMethod) {
-        this._authpacket = args;
-    }
 
     // Send out the data
     var id = this._callNo++, self = this;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Client library for interacting with the beam API.",
   "main": "index.js",
   "scripts": {
-    "test": "node node_modules/mocha/bin/mocha test/unit --recursive"
+    "test": "node node_modules/mocha/bin/mocha test/unit --recursive",
+    "cover": "istanbul cover _mocha -- test/unit --recursive"
   },
   "repository": {
     "type": "git",
@@ -26,6 +27,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-subset": "^1.2.0",
+    "istanbul": "^0.4.3",
     "mocha": "^2.2.1",
     "sinon": "^1.14.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-client-node",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "Client library for interacting with the beam API.",
   "main": "index.js",
   "scripts": {

--- a/test/unit/ws.test.js
+++ b/test/unit/ws.test.js
@@ -307,11 +307,14 @@ describe('websocket', function () {
             }));
         });
 
-        it('quietly removes the reply after a timeout', function () {
-            socket.call('foo', [1, 2, 3]);
+        it('quietly removes the reply after a timeout', function (done) {
+            socket.call('foo', [1, 2, 3]).catch(function (err) {
+                expect(err).to.be.an.instanceof(BeamSocket.TimeoutError);
+                expect(socket._replies[0]).not.to.be.defined;
+                done();
+            });
             expect(socket._replies[0]).to.be.defined;
             clock.tick(1000 * 60 + 1);
-            expect(socket._replies[0]).not.to.be.defined;
         });
     });
 });


### PR DESCRIPTION
I'm integrating the reference socket in our new frontend, and fixing several bugs while I'm at it. Namely:
 - **API/Breaking**: prefix 'private' members with an underscore
 - **Breaking**: Include a dedicated auth method and fix issues with authentication. Previously there were some issues, such as the promise never resolving if you called auth before the socket connected even though we supposedly spooled the reply. I include this as breaking since using `.call('auth', ` will no longer save those credentials to be reused on reconnect
 - **Breaking:** drop support for 0.12 (in our dependencies)
 - **Breaking:** on the chat server we now reply to _every_ method we get, so after a timeout we throw an error on the socket (where previously the promise returned from .call() would resolve to undefined) if we don't get a reply. The error class is exposed as `BeamSocket.TimeoutError`.
 - Add compatibility with browser-based sockets
 - Fix bias in round-robining
 - Use a backoff for chat reconnection
 - Use a generic A+ promise on BeamSocket.Promise so it can be swapped out by consumers (replacing with rsvp on our frontend)
 - Add unit tests where they were previously skimpy
 - Fix an issue with the socket re-opening if it was closed after a connection failure