### PR TITLE
Feature/pings

### DIFF
--- a/lib/ws/ws.d.ts
+++ b/lib/ws/ws.d.ts
@@ -4,7 +4,7 @@ declare class BeamSocket extends EventEmitter {
   /**
    * Constructor for the class to create the socket handle / connection.
    */
-  constructor(addresses: string[]);
+  constructor(addresses: string[], options?: { pingInterval: number, pingTimeout: number, callTimeout: number });
   /**
    * Which connection we use in our load balancing.
    */
@@ -40,7 +40,7 @@ declare class BeamSocket extends EventEmitter {
   /**
    * Number of milliseconds to wait in .call() before we give up waiting or the reply. Used to prevent leakages.
    */
-  callTimeout: number;
+  private _callTimeout: number;
   /**
    * Map of call IDs to promises that should be resolved on method responses.
    */
@@ -117,6 +117,10 @@ declare class BeamSocket extends EventEmitter {
   call(method: "whisper", args: [string, string], options?: CallOptions): Promise<any>;
   call(method: "history", args: [number], options?: CallOptions): Promise<ChatMessage[]>;
   call(method: "timeout", args: [string, string], options?: CallOptions): Promise<string>;
+  /**
+   * Pings the server to check if it's still alive.
+   */
+  ping(): Promise<void>;
 
   /**
    * Closes the websocket gracefully.

--- a/lib/ws/ws.js
+++ b/lib/ws/ws.js
@@ -1,5 +1,6 @@
 var util = require('util');
 var events = require('events');
+var _ = require('lodash');
 
 var Reply = require('./reply');
 var errors = require('../errors');
@@ -51,23 +52,6 @@ function timeout(delay) {
 }
 
 /**
- * Assigns enumerable properties of the src onto the obj, returning src.
- * Semi-polyfill for Object.assign.
- * @param  {Object} obj
- * @param  {Object} src
- * @return {Object}
- */
-function assign(src, obj) {
-    src = src || {};
-    obj = obj || {};
-    Object.keys(obj).forEach(function (key) {
-        src[key] = obj[key];
-    });
-
-    return src;
-}
-
-/**
  * Manages a connect to Beam's chat servers.
  * @access public
  * @param {Array} addresses
@@ -83,11 +67,11 @@ function assign(src, obj) {
 function BeamSocket (addresses, options) {
     events.EventEmitter.call(this);
 
-    options = assign({
+    options = _.defaults({
         pingInterval: 15 * 1000,
         pingTimeout: 5 * 1000,
         callTimeout: 20 * 1000,
-    }, options)
+    }, options);
 
     // Which connection we use in our load balancing.
     this._addressOffset = Math.floor(Math.random() * addresses.length);

--- a/lib/ws/ws.js
+++ b/lib/ws/ws.js
@@ -179,7 +179,7 @@ BeamSocket.prototype._getNextReconnectInterval = function () {
  * we weren't gracefully closed, we'll try to reconnect.
  */
 BeamSocket.prototype._handleClose = function () {
-    clearInterval(this._pingTimeoutHandle);
+    clearTimeout(this._pingTimeoutHandle);
     this._pingInterval = null;
     this.ws = null;
 

--- a/lib/ws/ws.js
+++ b/lib/ws/ws.js
@@ -496,10 +496,12 @@ BeamSocket.prototype.close = function () {
 };
 
 /**
- * Promise class to use in .call
+ * Promise class to use for various operations on the socket. The only
+ * requirement is that this be an A+ promise implementation. By default
+ * we try to require Bluebird, but you can switch it out with your own.
  * @type {Promise}
  */
-BeamSocket.Promise = require('bluebird');
+try { BeamSocket.Promise = require('bluebird'); } catch (e) {}
 
 /**
  * List of available statuses.

--- a/lib/ws/ws.js
+++ b/lib/ws/ws.js
@@ -9,12 +9,85 @@ var factory = require('./factory');
 var authMethod = 'auth';
 
 /**
+ * race takes an array of promises and is resolved with the first promise
+ * that resolves, or rejects. After the first resolve or rejection, all
+ * future resolutions and rejections will be discarded.
+ * @param {Promise[]} promises
+ * @return {Promise}
+ */
+function race(promises) {
+    return new BeamSocket.Promise(function (_resolve, _reject) {
+        var done = false;
+        function guard(fn) {
+            return function () {
+                if (!done) {
+                    done = true;
+                    fn.apply(null, arguments);
+                }
+            };
+        }
+
+        var resolve = guard(_resolve);
+        var reject = guard(_reject);
+
+        for (var i = 0; i < promises.length; i++) {
+            promises[i].then(resolve).catch(reject);
+        }
+    });
+}
+
+/**
+ * Return a promise which is rejected with a TimeoutError after the
+ * provided delay.
+ * @param  {Number} delay
+ * @return {Promise}
+ */
+function timeout(delay) {
+    return new BeamSocket.Promise(function (resolve, reject) {
+        setTimeout(function () {
+            reject(new TimeoutError());
+        }, delay);
+    });
+}
+
+/**
+ * Assigns enumerable properties of the src onto the obj, returning src.
+ * Semi-polyfill for Object.assign.
+ * @param  {Object} obj
+ * @param  {Object} src
+ * @return {Object}
+ */
+function assign(src, obj) {
+    src = src || {};
+    obj = obj || {};
+    Object.keys(obj).forEach(function (key) {
+        src[key] = obj[key];
+    });
+
+    return src;
+}
+
+/**
  * Manages a connect to Beam's chat servers.
  * @access public
  * @param {Array} addresses
+ * @param {Object} options
+ * @param {Number} [options.pingInterval=15000] How often to send ping packets
+ *     to  make sure the connection is alive. Given in milliseconds.
+ * @param {Number} [options.pingTimeout=5000] How long to wait after sending
+ *     a ping before, if we don't get a reply, we consider the connection dead.
+ * @param {Number} [options.callTimeout=20000] Number of milliseconds to wait
+ *     for a reply from the chat server before giving up and rejecting with
+ *     a TimeoutError. This can be overridden in the arguments to .call().
  */
-function BeamSocket (addresses) {
+function BeamSocket (addresses, options) {
     events.EventEmitter.call(this);
+
+    options = assign({
+        pingInterval: 15 * 1000,
+        pingTimeout: 5 * 1000,
+        callTimeout: 20 * 1000,
+    }, options)
 
     // Which connection we use in our load balancing.
     this._addressOffset = Math.floor(Math.random() * addresses.length);
@@ -28,6 +101,13 @@ function BeamSocket (addresses) {
     // The WebSocket instance we're currently connected with.
     this.ws = null;
 
+    // Information for server pings. We ping the server on the interval
+    // (if we don't get any other packets) and consider a connection
+    // dead if it doesn't respond within the timeout.
+    this._pingTimeoutHandle = null;
+    this._pingInterval = options.pingInterval;
+    this._pingTimeout = options.pingTimeout;
+
     // The status of the socket connection.
     this.status = BeamSocket.IDLE;
 
@@ -35,14 +115,12 @@ function BeamSocket (addresses) {
     // retries before we reset our reconnect attempts.
     this._retries = 0;
     this._retryWrap = 7; // max 2 minute retry time
-    // Wait duration between retries.
-    this.retryDelay = 500;
     // Timeout waiting to reconnect
     this._reconnectTimeout = null;
 
     // Number of milliseconds to wait in .call() before we give up waiting
     // for the reply. Used to prevent leakages.
-    this.callTimeout = 1000 * 60;
+    this._callTimeout = options.callTimeout;
 
     // Map of call IDs to promises that should be resolved on
     // method responses.
@@ -101,7 +179,10 @@ BeamSocket.prototype._getNextReconnectInterval = function () {
  * we weren't gracefully closed, we'll try to reconnect.
  */
 BeamSocket.prototype._handleClose = function () {
+    clearInterval(this._pingTimeoutHandle);
+    this._pingInterval = null;
     this.ws = null;
+
     if (this.status === BeamSocket.CLOSING) {
         this.status = BeamSocket.CLOSED;
         return this.emit('closed');
@@ -112,6 +193,67 @@ BeamSocket.prototype._handleClose = function () {
         this.boot.bind(this),
         this._getNextReconnectInterval()
     );
+};
+
+/**
+ * Sets the socket to send a ping message after an interval. This is
+ * called when a successful ping is received and after data is received
+ * from the socket (there's no need to ping when we know the socket
+ * is still alive).
+ */
+BeamSocket.prototype._resetPingTimeout = function () {
+    clearTimeout(this._pingTimeoutHandle);
+
+    var self = this;
+    this._pingTimeoutHandle = setTimeout(function () {
+        self.ping().catch(function () {});
+    }, this._pingInterval);
+};
+
+/**
+ * Ping runs a ping against the server and returns a promise which is
+ * resolved if the server responds, or rejected on timeout.
+ * @return {Promise}
+ */
+BeamSocket.prototype.ping = function () {
+    var ws = this.ws;
+    var self = this;
+    clearTimeout(this._pingTimeoutHandle);
+
+    if (!this.isConnected()) {
+        return new BeamSocket.Promise(function (resolve, reject) {
+            reject(new TimeoutError());
+        });
+    }
+
+    var promise;
+
+    if (typeof ws.ping === 'function') {
+        // Node's ws module has a ping function we can use rather than
+        // sending a message. More lightweight, less noisy.
+        promise = race([
+            timeout(this._pingTimeout),
+            new BeamSocket.Promise(function (resolve) {
+                ws.once('pong', resolve)
+            }),
+        ]);
+        ws.ping();
+    } else {
+        // Otherwise we'll resort to sending a ping message over the socket.
+        promise = this.call('ping', [], { timeout: this._pingTimeout });
+    }
+
+    return promise
+    .then(this._resetPingTimeout.bind(this))
+    .catch(TimeoutError, function (err) {
+        // If we haven't noticed the socket is dead since we started trying
+        // to ping, manually emit an error. This'll cause it to close.
+        if (self.ws === ws) {
+            self.ws.emit('error', err);
+        }
+
+        throw err;
+    });
 };
 
 /**
@@ -129,11 +271,13 @@ BeamSocket.prototype.boot = function () {
 
     // Websocket connection has been established.
     ws.on('open', function () {
+        self._resetPingTimeout();
         self.unspool.apply(self, arguments);
     });
 
     // We got an incoming data packet.
     ws.on('message', function () {
+        self._resetPingTimeout();
         self.parsePacket.apply(self, arguments);
     });
 
@@ -326,22 +470,14 @@ BeamSocket.prototype.call = function (method, args_, options_) {
         return;
     }
 
-    var timeout;
-    return new BeamSocket.Promise(function (resolve, reject) {
-        timeout = setTimeout(function () {
-            reject(new TimeoutError());
-        }, self.callTimeout);
-
-        self._replies[id] = new Reply(resolve, reject);
-    }).catch(function (err) {
-        // After five seconds, if we haven't gotten a reply, remove
-        // the method reply. Keeps memory leaks down.
-        if (err instanceof TimeoutError) {
-            delete self._replies[id];
-        }
+    return race([
+        timeout(options.timeout || this._callTimeout),
+        new BeamSocket.Promise(function (resolve, reject) {
+            self._replies[id] = new Reply(resolve, reject);
+        })
+    ]).catch(TimeoutError, function (err) {
+        delete self._replies[id];
         throw err;
-    }).finally(function () {
-        clearTimeout(timeout);
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-client-node",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Client library for interacting with the beam API.",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "istanbul": "^0.4.3",
     "mocha": "^2.2.1",
     "sinon": "^1.14.0",
+    "sinon-chai": "^2.8.0",
     "typings": "^1.0.4"
   },
   "dependencies": {

--- a/test/unit/_bootstrap.test.js
+++ b/test/unit/_bootstrap.test.js
@@ -2,6 +2,7 @@ var request = require('../../lib/request');
 var Client = require('../../lib/client');
 
 require('chai').use(require('chai-subset'));
+require('chai').use(require('sinon-chai'));
 
 beforeEach(function () {
     this.client = new Client();


### PR DESCRIPTION
This adds ping funtionality to the socket client to proactively detect disconnects/timeouts. Pings are sent, by default, if we go 15 seconds without any data from the socket and the server is given five seconds to respond before the client considers the connection to be dead. As a minor thing this also adds the ability to override various timing options in an optional object passed to the websocket constructor.

On our frontend it looks like this:

![](https://peet.io/i/16-06-e4kjym855ek2hbjzottmxows1ovwga.png)