### PR TITLE
Ensure chat errors are thrown

### DIFF
--- a/lib/ws/ws.js
+++ b/lib/ws/ws.js
@@ -466,7 +466,7 @@ BeamSocket.prototype.call = function (method, args_, options_) {
             self._replies[id] = new Reply(resolve, reject);
         }),
     ])
-    .catch(TimeoutError, function (err) {
+    .catch(function (err) {
         delete self._replies[id];
         throw err;
     });

--- a/lib/ws/ws.js
+++ b/lib/ws/ws.js
@@ -467,7 +467,9 @@ BeamSocket.prototype.call = function (method, args_, options_) {
         }),
     ])
     .catch(function (err) {
-        delete self._replies[id];
+        if (err instanceof TimeoutError) {
+            delete self._replies[id];
+        }
         throw err;
     });
 };


### PR DESCRIPTION
Chat errors, such as trying to send links when links are not permitted, were not getting thrown properly. They would result in a joi `ValidationError`, because it was trying to create an alert without a message on the frontend.

With this change, the errors make their way all the way up to the chat, and display in the chat banners properly.