### PR TITLE
Measure timeouts since the packet was sent rather than .call

### DIFF
--- a/lib/ws/ws.js
+++ b/lib/ws/ws.js
@@ -302,7 +302,8 @@ BeamSocket.prototype.unspool = function () {
     function bang () {
         // Send any spooled events that we have.
         for (var i = 0; i < self._spool.length; i++) {
-            self.send(self._spool[i], { force: true });
+            self.send(self._spool[i].data, { force: true });
+            self._spool[i].resolve();
         }
         self._spool = [];
 
@@ -388,19 +389,26 @@ BeamSocket.prototype.parsePacket = function (data, flags) {
  * @access protected
  * @param  {Object} data
  * @param  {Object} options_
+ * @return {Promise} resolved once the packet is sent
  * @fires BeamSocket#sent
  * @fires BeamSocket#spooled
  */
 BeamSocket.prototype.send = function (data, options_) {
     var options = options_ || {};
+    var self = this;
 
     if (this.isConnected() || options.force) {
         this.ws.send(JSON.stringify(data));
         this.emit('sent', data);
+        return BeamSocket.Promise.resolve();
     } else if (data.method !== authMethod) {
-        this._spool.push(data);
-        this.emit('spooled', data);
+        return new BeamSocket.Promise(function (resolve) {
+            self._spool.push({ data: data, resolve: resolve });
+            self.emit('spooled', data);
+        });
     }
+
+    return BeamSocket.Promise.resolve();
 };
 
 /**
@@ -451,21 +459,31 @@ BeamSocket.prototype.call = function (method, args_, options_) {
     // Send out the data
     var id = this._callNo++;
     var self = this;
-    this.send({ type: 'method', method: method, arguments: args, id: id }, options);
 
+    // This is created before we call and wait on .send purely for ease
+    // of use in tests, so that we can mock an incoming packet synchronously.
+    var replyPromise = new BeamSocket.Promise(function (resolve, reject) {
+        self._replies[id] = new Reply(resolve, reject);
+    });
 
-    // Then create and return a promise that's resolved when we get
-    // a reply, if we expect one to be given.
-    if (options.noReply) {
-        return BeamSocket.Promise.resolve();
-    }
+    return this.send({
+        type: 'method',
+        method: method,
+        arguments: args,
+        id: id,
+    }, options)
+    .then(function () {
+        // Then create and return a promise that's resolved when we get
+        // a reply, if we expect one to be given.
+        if (options.noReply) {
+            return BeamSocket.Promise.resolve();
+        }
 
-    return race([
-        timeout(options.timeout || this._callTimeout),
-        new BeamSocket.Promise(function (resolve, reject) {
-            self._replies[id] = new Reply(resolve, reject);
-        }),
-    ])
+        return race([
+            timeout(options.timeout || self._callTimeout),
+            replyPromise,
+        ]);
+    })
     .catch(function (err) {
         if (err instanceof TimeoutError) {
             delete self._replies[id];


### PR DESCRIPTION
Fixes https://trello.com/c/YPAPnyoC/67-chat-reconnection-issues; both issues there had the same root cause.

When the chat socket was disconnected for more than 20 seconds, the message promise got rejected even though it was spooled up and sent. Then, when the chat server responded after that message was sent, the client threw an error that the reply was unexpected resulting in the disconnected message appearing on the frontend.

This PR modifies the behaviour of .call so that the timeout doesn't start until the packet is actually sent over the socket.