### PR TITLE
Fix support for TypeScript 2.x

### DIFF
--- a/lib/client.d.ts
+++ b/lib/client.d.ts
@@ -1,3 +1,5 @@
+import Promise = require("bluebird");
+
 import ChannelService = require("./services/channel");
 import ChatService = require("./services/chat");
 import GameService = require("./services/game");

--- a/lib/providers/oauth.d.ts
+++ b/lib/providers/oauth.d.ts
@@ -1,3 +1,4 @@
+import Promise = require("bluebird");
 import Client = require("../client");
 
 import { BeamRequest } from "../../defs/request";

--- a/lib/providers/password.d.ts
+++ b/lib/providers/password.d.ts
@@ -1,4 +1,5 @@
-import * as request from "request";
+import Promise = require("bluebird");
+import request = require("request");
 
 import Client = require("../client");
 

--- a/lib/providers/provider.d.ts
+++ b/lib/providers/provider.d.ts
@@ -1,3 +1,4 @@
+import Promise = require("bluebird");
 import Client = require("../client");
 
 declare class Provider {

--- a/lib/services/channel.d.ts
+++ b/lib/services/channel.d.ts
@@ -1,3 +1,4 @@
+import Promise = require("bluebird");
 import Service = require("./service");
 
 import { BeamRequest } from "../../defs/request";

--- a/lib/services/game.d.ts
+++ b/lib/services/game.d.ts
@@ -1,3 +1,4 @@
+import Promise = require("bluebird");
 import Service = require("./service");
 
 import { BeamRequest } from "../../defs/request";

--- a/lib/services/service.d.ts
+++ b/lib/services/service.d.ts
@@ -1,3 +1,4 @@
+import Promise = require("bluebird");
 import Client = require("../client");
 
 declare class Service {


### PR DESCRIPTION
As the client uses Bluebird for the Promise spec we need to tell the definitions to use that version rather than the Vanilla one.

The ws.d.ts needs fixing also but as that works for both Vanilla and any spec something needs to be done custom or if something exists to cover them all.