### PR TITLE
This isn't Node, silly

### DIFF
--- a/lib/ws/ws.d.ts
+++ b/lib/ws/ws.d.ts
@@ -6,7 +6,7 @@ declare class BeamSocket extends EventEmitter {
     /**
      * Constructor for the class to create the socket handle / connection.
      */
-    constructor(addresses: string[], options?: { pingInterval: number, pingTimeout: number, callTimeout: number });
+    constructor(addresses: string[], options?: { pingInterval?: number, pingTimeout?: number, callTimeout?: number });
 
     /**
      * Which connection we use in our load balancing.

--- a/lib/ws/ws.js
+++ b/lib/ws/ws.js
@@ -248,11 +248,16 @@ BeamSocket.prototype.ping = function () {
 
     return promise
     .then(this._resetPingTimeout.bind(this))
-    .catch(TimeoutError, function (err) {
+    .catch(function (err) {
+        if (!(err instanceof TimeoutError)) {
+            throw err;
+        }
+
         // If we haven't noticed the socket is dead since we started trying
         // to ping, manually emit an error. This'll cause it to close.
         if (self.ws === ws) {
-            self.ws.emit('error', err);
+            self.emit('error', err);
+            ws.close();
         }
 
         throw err;


### PR DESCRIPTION
Several constructs used in the ping timeouts were dependent on Node-only features or Bluebird. This caused pings to be non-functional in browsers. Derp.